### PR TITLE
Fix link to decent patterns reddit

### DIFF
--- a/site/contribute.njk
+++ b/site/contribute.njk
@@ -31,7 +31,7 @@ title: Contribute
         </li>
         <li class="pt-4">Find us on Reddit for wide open discussions and community forum</li>
         <li>
-          <a href="https:/reddit.com/r/decentpatterns" class="link-reference">Reddit</a>
+          <a href="https://reddit.com/r/decentpatterns" class="link-reference">Reddit</a>
         </li>
         <li class="pt-4">To receive news and updates on our work, sign up for our newsletter
         </li>


### PR DESCRIPTION
When I visited the site at https://decentpatterns.xyz/contribute/, and clicked the Reddit link out of curiousity, I got a 404.

The link currently ends up as https://decentpatterns.xyz/reddit.com/r/decentpatterns, in my browser *(Firefox 80, on OS X), because there is a missing slash in the url.

I think this should resolve it.