### PR TITLE
Roadmap/css fix

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -76,7 +76,14 @@ if (mix.inProduction()) {
         "footnote-item",
         "aside",
         "take-aways",
-        "offers"
+        "offers",
+        "timeline",
+        "timeline__item",
+        "timeline__item__description",
+        "timeline__item__date",
+        "progress",
+        "done",
+        "idle"
       ]
     })
 


### PR DESCRIPTION
Skeleventy uses purgeCSS with a selector whitelist that needed to be update with css classes introduced in #5 in order to have them not be purged during the production build. However, I think this is not a sustainable approach but just a temporary fix around this.